### PR TITLE
Change height: 100vw to 100vh in readme

### DIFF
--- a/packages/mdx-deck/README.md
+++ b/packages/mdx-deck/README.md
@@ -130,7 +130,7 @@ export default ({ children }) => (
   <div
     style={{
       width: '100vw',
-      height: '100vw',
+      height: '100vh',
       backgroundColor: 'tomato',
     }}>
     {children}


### PR DESCRIPTION
In the example layout code, the CSS height was erroneously set to 100vw instead of 100vh.